### PR TITLE
Fix: Complete admin dark mode and theme toggle functionality

### DIFF
--- a/app/(admin)/admin/users/page.tsx
+++ b/app/(admin)/admin/users/page.tsx
@@ -49,19 +49,19 @@ export default async function AdminUsersPage() {
         {/* Header */}
         <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-8">
           <div>
-            <h1 className="text-3xl font-bold text-white mb-2">
+            <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
               User Management
             </h1>
-            <p className="text-gray-300">
+            <p className="text-gray-600 dark:text-gray-300">
               Manage user accounts and permissions across your platform
             </p>
           </div>
           <div className="flex gap-3 mt-4 md:mt-0">
-            <button className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
+            <button className="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white dark:bg-blue-500 dark:hover:bg-blue-600 rounded-lg transition-colors">
               <UserPlus className="h-4 w-4 mr-2" />
               Add User
             </button>
-            <button className="inline-flex items-center px-4 py-2 bg-gray-700 text-gray-300 rounded-lg hover:bg-gray-600 transition-colors">
+            <button className="inline-flex items-center px-4 py-2 bg-gray-200 hover:bg-gray-300 text-gray-700 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 rounded-lg transition-colors">
               <Download className="h-4 w-4 mr-2" />
               Export
             </button>
@@ -70,67 +70,67 @@ export default async function AdminUsersPage() {
 
         {/* Stats Cards */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-          <Card className="bg-gray-800 border-gray-700">
+          <Card>
             <CardContent className="p-6">
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-sm font-medium text-gray-400">
+                  <p className="text-sm font-medium text-gray-500 dark:text-gray-400">
                     Total Users
                   </p>
-                  <p className="text-2xl font-bold text-white">{totalUsers}</p>
+                  <p className="text-2xl font-bold text-gray-900 dark:text-white">{totalUsers}</p>
                 </div>
-                <div className="bg-blue-900/20 p-3 rounded-full">
-                  <Users className="h-6 w-6 text-blue-400" />
+                <div className="bg-blue-100 dark:bg-blue-900/20 p-3 rounded-full">
+                  <Users className="h-6 w-6 text-blue-600 dark:text-blue-400" />
                 </div>
               </div>
             </CardContent>
           </Card>
 
-          <Card className="bg-gray-800 border-gray-700">
+          <Card>
             <CardContent className="p-6">
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-sm font-medium text-gray-400">
+                  <p className="text-sm font-medium text-gray-500 dark:text-gray-400">
                     Administrators
                   </p>
-                  <p className="text-2xl font-bold text-white">{adminCount}</p>
+                  <p className="text-2xl font-bold text-gray-900 dark:text-white">{adminCount}</p>
                 </div>
-                <div className="bg-red-900/20 p-3 rounded-full">
-                  <Users className="h-6 w-6 text-red-400" />
+                <div className="bg-red-100 dark:bg-red-900/20 p-3 rounded-full">
+                  <Users className="h-6 w-6 text-red-600 dark:text-red-400" />
                 </div>
               </div>
             </CardContent>
           </Card>
 
-          <Card className="bg-gray-800 border-gray-700">
+          <Card>
             <CardContent className="p-6">
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-sm font-medium text-gray-400">
+                  <p className="text-sm font-medium text-gray-500 dark:text-gray-400">
                     Moderators
                   </p>
-                  <p className="text-2xl font-bold text-white">
+                  <p className="text-2xl font-bold text-gray-900 dark:text-white">
                     {moderatorCount}
                   </p>
                 </div>
-                <div className="bg-yellow-900/20 p-3 rounded-full">
-                  <Users className="h-6 w-6 text-yellow-400" />
+                <div className="bg-yellow-100 dark:bg-yellow-900/20 p-3 rounded-full">
+                  <Users className="h-6 w-6 text-yellow-600 dark:text-yellow-400" />
                 </div>
               </div>
             </CardContent>
           </Card>
 
-          <Card className="bg-gray-800 border-gray-700">
+          <Card>
             <CardContent className="p-6">
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-sm font-medium text-gray-400">
+                  <p className="text-sm font-medium text-gray-500 dark:text-gray-400">
                     Regular Users
                   </p>
-                  <p className="text-2xl font-bold text-white">{userCount}</p>
+                  <p className="text-2xl font-bold text-gray-900 dark:text-white">{userCount}</p>
                 </div>
-                <div className="bg-green-900/20 p-3 rounded-full">
-                  <Users className="h-6 w-6 text-green-400" />
+                <div className="bg-green-100 dark:bg-green-900/20 p-3 rounded-full">
+                  <Users className="h-6 w-6 text-green-600 dark:text-green-400" />
                 </div>
               </div>
             </CardContent>
@@ -138,18 +138,18 @@ export default async function AdminUsersPage() {
         </div>
 
         {/* Search and Filter Bar */}
-        <Card className="bg-gray-800 border-gray-700">
+        <Card>
           <CardContent className="p-6">
             <div className="flex flex-col md:flex-row gap-4">
               <div className="relative flex-1">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-500 dark:text-gray-400" />
                 <input
                   type="text"
                   placeholder="Search users by name or email..."
-                  className="w-full pl-10 pr-4 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full pl-10 pr-4 py-2 bg-white border border-gray-300 text-gray-900 placeholder-gray-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                 />
               </div>
-              <button className="inline-flex items-center px-4 py-2 bg-gray-700 text-gray-300 rounded-lg hover:bg-gray-600 transition-colors">
+              <button className="inline-flex items-center px-4 py-2 bg-gray-200 hover:bg-gray-300 text-gray-700 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 rounded-lg transition-colors">
                 <Filter className="h-4 w-4 mr-2" />
                 Filter
               </button>
@@ -158,39 +158,39 @@ export default async function AdminUsersPage() {
         </Card>
 
         {/* Users Table */}
-        <Card className="bg-gray-800 border-gray-700">
+        <Card>
           <CardHeader>
-            <CardTitle className="text-white">
+            <CardTitle className="text-gray-900 dark:text-white">
               All Users ({totalUsers})
             </CardTitle>
           </CardHeader>
           <CardContent className="p-0">
             <div className="overflow-x-auto">
               <table className="w-full">
-                <thead className="bg-gray-750">
-                  <tr className="border-b border-gray-700">
-                    <th className="px-6 py-4 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">
+                <thead className="bg-gray-100 dark:bg-gray-750">
+                  <tr className="border-b border-gray-200 dark:border-gray-700">
+                    <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                       User
                     </th>
-                    <th className="px-6 py-4 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">
+                    <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                       Email
                     </th>
-                    <th className="px-6 py-4 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">
+                    <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                       Role
                     </th>
-                    <th className="px-6 py-4 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">
+                    <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                       Join Date
                     </th>
-                    <th className="px-6 py-4 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">
+                    <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                       Actions
                     </th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-gray-700">
+                <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
                   {users.map((user) => (
                     <tr
                       key={user.id}
-                      className="hover:bg-gray-700/50 transition-colors"
+                      className="hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
                     >
                       <td className="px-6 py-4 whitespace-nowrap">
                         <div className="flex items-center">
@@ -202,22 +202,22 @@ export default async function AdminUsersPage() {
                               alt={user.name || ""}
                             />
                           ) : (
-                            <div className="h-10 w-10 rounded-full bg-gray-600 flex items-center justify-center mr-4">
-                              <Users className="h-5 w-5 text-gray-300" />
+                            <div className="h-10 w-10 rounded-full bg-gray-300 dark:bg-gray-600 flex items-center justify-center mr-4">
+                              <Users className="h-5 w-5 text-gray-500 dark:text-gray-300" />
                             </div>
                           )}
                           <div>
-                            <div className="text-sm font-medium text-white">
+                            <div className="text-sm font-medium text-gray-900 dark:text-white">
                               {user.name || "No name"}
                             </div>
-                            <div className="text-sm text-gray-400">
+                            <div className="text-sm text-gray-500 dark:text-gray-400">
                               ID: {user.id.slice(0, 8)}...
                             </div>
                           </div>
                         </div>
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="text-sm text-gray-300">
+                        <div className="text-sm text-gray-700 dark:text-gray-300">
                           {user.email}
                         </div>
                       </td>
@@ -228,19 +228,19 @@ export default async function AdminUsersPage() {
                             font-medium
                             ${
                               user.role === "ADMIN"
-                                ? "bg-red-900/50 text-red-200 border-red-700"
+                                ? "bg-red-100 text-red-700 border-red-200 dark:bg-red-900/50 dark:text-red-200 dark:border-red-700"
                                 : user.role === "MODERATOR"
-                                  ? "bg-yellow-900/50 text-yellow-200 border-yellow-700"
+                                  ? "bg-yellow-100 text-yellow-700 border-yellow-200 dark:bg-yellow-900/50 dark:text-yellow-200 dark:border-yellow-700"
                                   : user.role === "USER"
-                                    ? "bg-green-900/50 text-green-200 border-green-700"
-                                    : "bg-gray-700 text-gray-200 border-gray-600"
+                                    ? "bg-green-100 text-green-700 border-green-200 dark:bg-green-900/50 dark:text-green-200 dark:border-green-700"
+                                    : "bg-gray-100 text-gray-700 border-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:border-gray-600"
                             }
                           `}
                         >
                           {user.role}
                         </Badge>
                       </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-400">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                         {new Date(user.createdAt).toLocaleDateString("en-US", {
                           year: "numeric",
                           month: "short",

--- a/app/(admin)/layout.tsx
+++ b/app/(admin)/layout.tsx
@@ -9,28 +9,6 @@ export default function AdminLayout({
 }) {
   return (
     <>
-      <script
-        dangerouslySetInnerHTML={{
-          __html: `
-            (function() {
-              try {
-                const savedTheme = document.cookie
-                  .split('; ')
-                  .find(row => row.startsWith('admin-theme='))
-                  ?.split('=')[1] || 'dark';
-
-                document.documentElement.classList.add(savedTheme);
-                document.documentElement.setAttribute('data-theme', savedTheme);
-                document.body.classList.add(savedTheme);
-              } catch (e) {
-                document.documentElement.classList.add('dark');
-                document.documentElement.setAttribute('data-theme', 'dark');
-                document.body.classList.add('dark');
-              }
-            })()
-          `,
-        }}
-      />
       <ThemeProvider>
         <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
           <AdminSidebar />

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,10 +1,5 @@
 @import "tailwindcss";
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -80,6 +75,7 @@
   --sidebar-ring: oklch(0.704 0.04 256.788);
 }
 
+/* Dark theme variables, applied when html has .dark class */
 .dark {
   --background: oklch(0 0 0 / 0.6);
   --foreground: oklch(0.98 0 0);
@@ -118,13 +114,6 @@
   --sidebar-accent-foreground: oklch(0.984 0.003 247.858);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.551 0.027 264.364);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
 }
 
 @layer base {

--- a/components/admin/AdminDashboardClient.tsx
+++ b/components/admin/AdminDashboardClient.tsx
@@ -36,6 +36,7 @@ import {
 } from "lucide-react";
 import CountUp from "react-countup";
 import { API_KEY_PROFILES } from "@/app/services/elevenlabs-implementation";
+import { useTheme } from "next-themes";
 
 interface DashboardData {
   stats: {
@@ -113,6 +114,7 @@ const ROLE_COLORS = {
 
 export function AdminDashboardClient({ data }: { data: DashboardData }) {
   const { stats, recentUsers, userGrowthData, analytics } = data;
+  const { theme } = useTheme();
 
   // State for real-time VN sales and voice data
   const [vnSalesData, setVnSalesData] = useState(data.vnSales);
@@ -621,15 +623,15 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
           return (
             <Card
               key={index}
-              className="bg-gray-800 border-gray-700 overflow-hidden hover:bg-gray-750 transition-colors"
+              className="overflow-hidden hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors"
             >
               <CardContent className="p-6">
                 <div className="flex items-center justify-between">
                   <div className="space-y-2">
-                    <p className="text-sm font-medium text-gray-400">
+                    <p className="text-sm font-medium text-gray-500 dark:text-gray-400">
                       {stat.title}
                     </p>
-                    <p className="text-2xl font-bold text-white">
+                    <p className="text-2xl font-bold text-gray-900 dark:text-white">
                       {(stat as any).isLoading ? (
                         <div className="flex items-center">
                           <Loader2 className="h-6 w-6 animate-spin mr-2" />
@@ -650,10 +652,10 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                         />
                       )}
                     </p>
-                    <p className="text-xs text-gray-500">{stat.description}</p>
+                    <p className="text-xs text-gray-600 dark:text-gray-500">{stat.description}</p>
                   </div>
                   <div
-                    className={`${stat.bgColor} p-3 rounded-full bg-opacity-20`}
+                    className={`${stat.bgColor} p-3 rounded-full`}
                   >
                     <Icon className={`h-6 w-6 ${stat.color}`} />
                   </div>
@@ -668,10 +670,10 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Top Performing Messages Leaderboard */}
-        <Card className="bg-gray-800 border-gray-700">
+        <Card>
           <CardHeader>
-            <CardTitle className="flex items-center space-x-2 text-white">
-              <Trophy className="h-5 w-5 text-blue-400" />
+            <CardTitle className="flex items-center space-x-2 text-gray-900 dark:text-white">
+              <Trophy className="h-5 w-5 text-blue-600 dark:text-blue-400" />
               <span>MM Campaigns Leaderboard</span>
             </CardTitle>
           </CardHeader>
@@ -679,7 +681,7 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
             <div className="space-y-4">
               {isLoadingMassMessages ? (
                 <div className="flex justify-center py-8">
-                  <div className="flex items-center text-gray-400">
+                  <div className="flex items-center text-gray-600 dark:text-gray-400">
                     <Loader2 className="h-6 w-6 animate-spin mr-2" />
                     <span>Loading top performing messages...</span>
                   </div>
@@ -690,14 +692,14 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                     const getRankIcon = (rank: number) => {
                       switch (rank) {
                         case 1:
-                          return <Trophy className="h-5 w-5 text-yellow-400" />;
+                          return <Trophy className="h-5 w-5 text-yellow-500 dark:text-yellow-400" />;
                         case 2:
-                          return <Medal className="h-5 w-5 text-gray-400" />;
+                          return <Medal className="h-5 w-5 text-gray-500 dark:text-gray-400" />;
                         case 3:
-                          return <Award className="h-5 w-5 text-amber-600" />;
+                          return <Award className="h-5 w-5 text-amber-600 dark:text-amber-500" />;
                         default:
                           return (
-                            <div className="h-5 w-5 rounded-full bg-gray-600 flex items-center justify-center text-white text-xs font-bold">
+                            <div className="h-5 w-5 rounded-full bg-gray-300 dark:bg-gray-600 flex items-center justify-center text-gray-700 dark:text-white text-xs font-bold">
                               {rank}
                             </div>
                           );
@@ -705,15 +707,16 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                     };
 
                     const getRankStyle = (rank: number) => {
+                      // Added light mode backgrounds and borders
                       switch (rank) {
                         case 1:
-                          return "bg-gradient-to-r from-yellow-500/20 to-yellow-600/20 border-yellow-500/30";
+                          return "bg-yellow-50 border-yellow-200 dark:bg-gradient-to-r from-yellow-500/20 to-yellow-600/20 dark:border-yellow-500/30";
                         case 2:
-                          return "bg-gradient-to-r from-gray-400/20 to-gray-500/20 border-gray-400/30";
+                          return "bg-gray-50 border-gray-200 dark:bg-gradient-to-r from-gray-400/20 to-gray-500/20 dark:border-gray-400/30";
                         case 3:
-                          return "bg-gradient-to-r from-amber-600/20 to-amber-700/20 border-amber-600/30";
+                          return "bg-amber-50 border-amber-200 dark:bg-gradient-to-r from-amber-600/20 to-amber-700/20 dark:border-amber-600/30";
                         default:
-                          return "bg-gray-700/50 border-gray-600/30";
+                          return "bg-gray-100 border-gray-200 dark:bg-gray-700/50 dark:border-gray-600/30";
                       }
                     };
 
@@ -740,10 +743,10 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                                 </div>
                               )}
                               <div>
-                                <h3 className="font-medium text-white">
+                                <h3 className="font-medium text-gray-900 dark:text-white">
                                   {message.modelName}
                                 </h3>
-                                <p className="text-xs text-gray-400">
+                                <p className="text-xs text-gray-500 dark:text-gray-400">
                                   @{message.modelUsername}
                                 </p>
                               </div>
@@ -758,7 +761,7 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                             {!message.isFree && message.price && (
                               <Badge
                                 variant="outline"
-                                className="bg-green-50 text-green-700"
+                                className="bg-green-100 text-green-700 dark:bg-green-500/10 dark:text-green-400 border-green-200 dark:border-green-500/30"
                               >
                                 ${message.price}
                               </Badge>
@@ -768,12 +771,12 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
 
                         <div className="mb-3">
                           <div
-                            className="text-sm text-gray-300 line-clamp-2"
+                            className="text-sm text-gray-700 dark:text-gray-300 line-clamp-2"
                             dangerouslySetInnerHTML={{
                               __html: message.textCropped,
                             }}
                           />
-                          <p className="text-xs text-gray-500 mt-1">
+                          <p className="text-xs text-gray-500 dark:text-gray-500 mt-1">
                             {new Date(message.date).toLocaleDateString()} at{" "}
                             {new Date(message.date).toLocaleTimeString()}
                           </p>
@@ -782,38 +785,38 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                         <div className="flex items-center justify-between">
                           <div className="flex items-center space-x-6">
                             <div className="text-center">
-                              <p className="font-bold text-xl text-blue-400">
+                              <p className="font-bold text-xl text-blue-600 dark:text-blue-400">
                                 {message.viewedCount.toLocaleString()}
                               </p>
-                              <p className="text-xs text-gray-400">views</p>
+                              <p className="text-xs text-gray-500 dark:text-gray-400">views</p>
                             </div>
                             <div className="text-center">
-                              <p className="font-semibold text-lg text-gray-300">
+                              <p className="font-semibold text-lg text-gray-700 dark:text-gray-300">
                                 {message.sentCount.toLocaleString()}
                               </p>
-                              <p className="text-xs text-gray-400">sent</p>
+                              <p className="text-xs text-gray-500 dark:text-gray-400">sent</p>
                             </div>
                             <div className="text-center">
-                              <p className="font-semibold text-lg text-green-400">
+                              <p className="font-semibold text-lg text-green-600 dark:text-green-400">
                                 {message.viewRate.toFixed(1)}%
                               </p>
-                              <p className="text-xs text-gray-400">view rate</p>
+                              <p className="text-xs text-gray-500 dark:text-gray-400">view rate</p>
                             </div>
                             {!message.isFree && (
                               <>
                                 <div className="text-center">
-                                  <p className="font-semibold text-lg text-purple-400">
+                                  <p className="font-semibold text-lg text-purple-600 dark:text-purple-400">
                                     {message.purchasedCount}
                                   </p>
-                                  <p className="text-xs text-gray-400">
+                                  <p className="text-xs text-gray-500 dark:text-gray-400">
                                     purchases
                                   </p>
                                 </div>
                                 <div className="text-center">
-                                  <p className="font-semibold text-lg text-yellow-400">
+                                  <p className="font-semibold text-lg text-yellow-600 dark:text-yellow-400">
                                     ${message.revenue.toFixed(2)}
                                   </p>
-                                  <p className="text-xs text-gray-400">
+                                  <p className="text-xs text-gray-500 dark:text-gray-400">
                                     revenue
                                   </p>
                                 </div>
@@ -823,7 +826,7 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
 
                           {message.rank === 1 && (
                             <div className="flex items-center">
-                              <span className="text-xs bg-yellow-500/20 text-yellow-400 px-2 py-1 rounded-full">
+                              <span className="text-xs bg-yellow-100 text-yellow-700 dark:bg-yellow-500/20 dark:text-yellow-400 px-2 py-1 rounded-full">
                                 👑 Top Message
                               </span>
                             </div>
@@ -832,12 +835,12 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                       </div>
                     );
                   })}
-                  <div className="text-center text-gray-400 py-4 border-t border-gray-600 mt-4">
+                  <div className="text-center text-gray-600 dark:text-gray-400 py-4 border-t border-gray-200 dark:border-gray-600 mt-4">
                     <div className="flex justify-center space-x-8">
                       <div>
                         <p className="text-sm">
                           Top Message Views:{" "}
-                          <span className="text-blue-400 font-semibold">
+                          <span className="text-blue-600 dark:text-blue-400 font-semibold">
                             {topPerformingMessages[0]?.viewedCount.toLocaleString() ||
                               "0"}
                           </span>
@@ -846,7 +849,7 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                       <div>
                         <p className="text-sm">
                           Avg View Rate (Top 5):{" "}
-                          <span className="text-green-400 font-semibold">
+                          <span className="text-green-600 dark:text-green-400 font-semibold">
                             {topPerformingMessages.length > 0
                               ? (
                                   topPerformingMessages
@@ -865,7 +868,7 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                       <div>
                         <p className="text-sm">
                           Total Messages Analyzed:{" "}
-                          <span className="text-purple-400 font-semibold">
+                          <span className="text-purple-600 dark:text-purple-400 font-semibold">
                             {topPerformingMessages.length.toLocaleString()}
                           </span>
                         </p>
@@ -874,7 +877,7 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                   </div>
                 </>
               ) : (
-                <div className="text-center text-gray-400 py-8">
+                <div className="text-center text-gray-600 dark:text-gray-400 py-8">
                   <Eye className="h-12 w-12 mx-auto mb-4 opacity-50" />
                   <p className="text-sm">
                     No mass messaging data found. Start sending campaigns to see
@@ -887,10 +890,10 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
         </Card>
 
         {/* MM Campaign Leaderboards */}
-        <Card className="bg-gray-800 border-gray-700">
+        <Card>
           <CardHeader>
-            <CardTitle className="flex items-center space-x-2 text-white">
-              <Trophy className="h-5 w-5 text-yellow-400" />
+            <CardTitle className="flex items-center space-x-2 text-gray-900 dark:text-white">
+              <Trophy className="h-5 w-5 text-yellow-500 dark:text-yellow-400" />
               <span>MM Campaign Champion Leaderboards</span>
             </CardTitle>
           </CardHeader>
@@ -898,7 +901,7 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
             <div className="space-y-4">
               {isLoadingMassMessages ? (
                 <div className="flex justify-center py-8">
-                  <div className="flex items-center text-gray-400">
+                  <div className="flex items-center text-gray-600 dark:text-gray-400">
                     <Loader2 className="h-6 w-6 animate-spin mr-2" />
                     <span>Loading MM leaderboard...</span>
                   </div>
@@ -909,14 +912,14 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                     const getTrophyIcon = (rank: number) => {
                       switch (rank) {
                         case 1:
-                          return <Trophy className="h-6 w-6 text-yellow-400" />;
+                          return <Trophy className="h-6 w-6 text-yellow-500 dark:text-yellow-400" />;
                         case 2:
-                          return <Medal className="h-6 w-6 text-gray-400" />;
+                          return <Medal className="h-6 w-6 text-gray-500 dark:text-gray-400" />;
                         case 3:
-                          return <Award className="h-6 w-6 text-amber-600" />;
+                          return <Award className="h-6 w-6 text-amber-600 dark:text-amber-500" />;
                         default:
                           return (
-                            <div className="h-6 w-6 rounded-full bg-gray-600 flex items-center justify-center text-white text-sm font-bold">
+                            <div className="h-6 w-6 rounded-full bg-gray-300 dark:bg-gray-600 flex items-center justify-center text-gray-700 dark:text-white text-sm font-bold">
                               {rank}
                             </div>
                           );
@@ -924,15 +927,16 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                     };
 
                     const getRankStyle = (rank: number) => {
+                      // Added light mode backgrounds and borders
                       switch (rank) {
                         case 1:
-                          return "bg-gradient-to-r from-yellow-500/20 to-yellow-600/20 border-yellow-500/30";
+                          return "bg-yellow-50 border-yellow-200 dark:bg-gradient-to-r from-yellow-500/20 to-yellow-600/20 dark:border-yellow-500/30";
                         case 2:
-                          return "bg-gradient-to-r from-gray-400/20 to-gray-500/20 border-gray-400/30";
+                          return "bg-gray-50 border-gray-200 dark:bg-gradient-to-r from-gray-400/20 to-gray-500/20 dark:border-gray-400/30";
                         case 3:
-                          return "bg-gradient-to-r from-amber-600/20 to-amber-700/20 border-amber-600/30";
+                          return "bg-amber-50 border-amber-200 dark:bg-gradient-to-r from-amber-600/20 to-amber-700/20 dark:border-amber-600/30";
                         default:
-                          return "bg-gray-700/50 border-gray-600/30";
+                          return "bg-gray-100 border-gray-200 dark:bg-gray-700/50 dark:border-gray-600/30";
                       }
                     };
 
@@ -959,10 +963,10 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                                 </div>
                               )}
                               <div>
-                                <h3 className="font-semibold text-white">
+                                <h3 className="font-semibold text-gray-900 dark:text-white">
                                   {model.name}
                                 </h3>
-                                <p className="text-sm text-gray-400">
+                                <p className="text-sm text-gray-500 dark:text-gray-400">
                                   @{model.username}
                                 </p>
                               </div>
@@ -973,26 +977,26 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                           <div className="flex flex-col space-y-1">
                             <div className="flex items-center justify-end space-x-4">
                               <div className="text-right">
-                                <p className="font-bold text-2xl text-green-400">
+                                <p className="font-bold text-2xl text-green-600 dark:text-green-400">
                                   ${model.totalRevenue.toLocaleString()}
                                 </p>
-                                <p className="text-xs text-gray-400">
+                                <p className="text-xs text-gray-500 dark:text-gray-400">
                                   total revenue
                                 </p>
                               </div>
                               <div className="text-right">
-                                <p className="font-bold text-xl text-purple-400">
+                                <p className="font-bold text-xl text-purple-600 dark:text-purple-400">
                                   {model.totalViews.toLocaleString()}
                                 </p>
-                                <p className="text-xs text-gray-400">
+                                <p className="text-xs text-gray-500 dark:text-gray-400">
                                   total views
                                 </p>
                               </div>
                               <div className="text-right">
-                                <p className="font-bold text-lg text-blue-400">
+                                <p className="font-bold text-lg text-blue-600 dark:text-blue-400">
                                   {model.viewRate.toFixed(1)}%
                                 </p>
-                                <p className="text-xs text-gray-400">
+                                <p className="text-xs text-gray-500 dark:text-gray-400">
                                   view rate
                                 </p>
                               </div>
@@ -1001,32 +1005,32 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                             <div className="flex items-center justify-end space-x-3 mt-2">
                               <div className="flex items-center space-x-1">
                                 <div className="w-2 h-2 bg-green-500 rounded-full"></div>
-                                <span className="text-xs text-green-400">
+                                <span className="text-xs text-green-600 dark:text-green-400">
                                   {model.freeMessages} free
                                 </span>
                               </div>
                               <div className="flex items-center space-x-1">
                                 <div className="w-2 h-2 bg-yellow-500 rounded-full"></div>
-                                <span className="text-xs text-yellow-400">
+                                <span className="text-xs text-yellow-600 dark:text-yellow-400">
                                   {model.paidMessages} paid
                                 </span>
                               </div>
                               <div className="flex items-center space-x-1">
                                 <div className="w-2 h-2 bg-orange-500 rounded-full"></div>
-                                <span className="text-xs text-orange-400">
+                                <span className="text-xs text-orange-600 dark:text-orange-400">
                                   {model.totalPurchases} purchases
                                 </span>
                               </div>
                             </div>
 
                             <div className="flex items-center justify-end space-x-4 mt-1">
-                              <p className="text-xs text-gray-500">
+                              <p className="text-xs text-gray-500 dark:text-gray-500">
                                 Avg Price:{" "}
-                                <span className="text-green-300">
+                                <span className="text-green-700 dark:text-green-300">
                                   ${model.averagePrice.toFixed(2)}
                                 </span>
                               </p>
-                              <p className="text-xs text-gray-500">
+                              <p className="text-xs text-gray-500 dark:text-gray-500">
                                 {model.totalMessages} msgs •{" "}
                                 {model.totalSent.toLocaleString()} sent
                               </p>
@@ -1035,21 +1039,21 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
 
                           {model.rank === 1 && (
                             <div className="flex items-center justify-end mt-2">
-                              <span className="text-xs bg-green-500/20 text-green-400 px-2 py-1 rounded-full">
+                              <span className="text-xs bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400 px-2 py-1 rounded-full">
                                 💰 Revenue Champion
                               </span>
                             </div>
                           )}
                           {model.rank === 2 && (
                             <div className="flex items-center justify-end mt-2">
-                              <span className="text-xs bg-gray-500/20 text-gray-400 px-2 py-1 rounded-full">
+                              <span className="text-xs bg-gray-100 text-gray-700 dark:bg-gray-500/20 dark:text-gray-400 px-2 py-1 rounded-full">
                                 🥈 Runner-up
                               </span>
                             </div>
                           )}
                           {model.rank === 3 && (
                             <div className="flex items-center justify-end mt-2">
-                              <span className="text-xs bg-amber-600/20 text-amber-600 px-2 py-1 rounded-full">
+                              <span className="text-xs bg-amber-100 text-amber-700 dark:bg-amber-600/20 dark:text-amber-600 px-2 py-1 rounded-full">
                                 🥉 Third Place
                               </span>
                             </div>
@@ -1058,12 +1062,12 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                       </div>
                     );
                   })}
-                  <div className="text-center text-gray-400 py-4 border-t border-gray-600 mt-4">
+                  <div className="text-center text-gray-600 dark:text-gray-400 py-4 border-t border-gray-200 dark:border-gray-600 mt-4">
                     <div className="flex justify-center space-x-8">
                       <div>
                         <p className="text-sm">
                           Total Messages:{" "}
-                          <span className="text-orange-400 font-semibold">
+                          <span className="text-orange-600 dark:text-orange-400 font-semibold">
                             {totalMassMessages.toLocaleString()}
                           </span>
                         </p>
@@ -1071,7 +1075,7 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                       <div>
                         <p className="text-sm">
                           Total Revenue:{" "}
-                          <span className="text-green-400 font-semibold">
+                          <span className="text-green-600 dark:text-green-400 font-semibold">
                             $
                             {massMessagingLeaderboard
                               .reduce(
@@ -1085,7 +1089,7 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                       <div>
                         <p className="text-sm">
                           Total Views:{" "}
-                          <span className="text-purple-400 font-semibold">
+                          <span className="text-purple-600 dark:text-purple-400 font-semibold">
                             {massMessagingLeaderboard
                               .reduce((sum, model) => sum + model.totalViews, 0)
                               .toLocaleString()}
@@ -1095,7 +1099,7 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                       <div>
                         <p className="text-sm">
                           Avg View Rate:{" "}
-                          <span className="text-blue-400 font-semibold">
+                          <span className="text-blue-600 dark:text-blue-400 font-semibold">
                             {massMessagingLeaderboard.length > 0
                               ? (
                                   massMessagingLeaderboard.reduce(
@@ -1111,7 +1115,7 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                       <div>
                         <p className="text-sm">
                           Total Purchases:{" "}
-                          <span className="text-orange-400 font-semibold">
+                          <span className="text-orange-600 dark:text-orange-400 font-semibold">
                             {massMessagingLeaderboard
                               .reduce(
                                 (sum, model) => sum + model.totalPurchases,
@@ -1125,7 +1129,7 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                   </div>
                 </>
               ) : (
-                <div className="text-center text-gray-400 py-8">
+                <div className="text-center text-gray-600 dark:text-gray-400 py-8">
                   <Trophy className="h-12 w-12 mx-auto mb-4 opacity-50" />
                   <p className="text-sm">
                     No mass messaging data found. Start sending campaigns to see
@@ -1141,44 +1145,53 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
       {/* Charts Row */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* User Growth Chart */}
-        <Card className="bg-gray-800 border-gray-700">
+        <Card>
           <CardHeader>
-            <CardTitle className="flex items-center space-x-2 text-white">
-              <Activity className="h-5 w-5 text-blue-400" />
+            <CardTitle className="flex items-center space-x-2 text-gray-900 dark:text-white">
+              <Activity className="h-5 w-5 text-blue-600 dark:text-blue-400" />
               <span>User Growth (12 Months)</span>
             </CardTitle>
           </CardHeader>
           <CardContent>
             <ResponsiveContainer width="100%" height={300}>
               <LineChart data={userGrowthData}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+                <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? "#374151" : "#e5e7eb"} />
                 <XAxis
                   dataKey="month"
                   fontSize={12}
                   tickLine={false}
                   axisLine={false}
-                  tick={{ fill: "#9ca3af" }}
+                  tick={{ fill: theme === 'dark' ? "#9ca3af" : "#6b7280" }}
                 />
                 <YAxis
                   fontSize={12}
                   tickLine={false}
                   axisLine={false}
-                  tick={{ fill: "#9ca3af" }}
+                  tick={{ fill: theme === 'dark' ? "#9ca3af" : "#6b7280" }}
                 />
                 <Tooltip
-                  contentStyle={{
-                    backgroundColor: "#1f2937",
-                    border: "1px solid #374151",
-                    borderRadius: "8px",
-                    color: "#fff",
-                  }}
+                  contentStyle={
+                    theme === 'dark'
+                      ? {
+                          backgroundColor: "#1f2937",
+                          border: "1px solid #374151",
+                          borderRadius: "8px",
+                          color: "#fff",
+                        }
+                      : {
+                          backgroundColor: "#ffffff",
+                          border: "1px solid #e5e7eb",
+                          borderRadius: "8px",
+                          color: "#000",
+                        }
+                  }
                 />
                 <Line
                   type="monotone"
                   dataKey="users"
-                  stroke="#60a5fa"
+                  stroke={theme === 'dark' ? "#60a5fa" : "#3b82f6"} // Adjusted light mode color for better visibility
                   strokeWidth={3}
-                  dot={{ fill: "#60a5fa", strokeWidth: 2 }}
+                  dot={{ fill: theme === 'dark' ? "#60a5fa" : "#3b82f6", strokeWidth: 2 }}
                 />
               </LineChart>
             </ResponsiveContainer>
@@ -1186,10 +1199,10 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
         </Card>
 
         {/* Users by Role Chart */}
-        <Card className="bg-gray-800 border-gray-700">
+        <Card>
           <CardHeader>
-            <CardTitle className="flex items-center space-x-2 text-white">
-              <UserCheck className="h-5 w-5 text-green-400" />
+            <CardTitle className="flex items-center space-x-2 text-gray-900 dark:text-white">
+              <UserCheck className="h-5 w-5 text-green-600 dark:text-green-400" />
               <span>Users by Role</span>
             </CardTitle>
           </CardHeader>
@@ -1207,18 +1220,28 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                   outerRadius={80}
                   fill="#8884d8"
                   dataKey="value"
+                  labelStyle={{ fill: theme === 'dark' ? "#9ca3af" : "#4b5563", fontSize: 12 }}
                 >
                   {roleChartData.map((entry, index) => (
                     <Cell key={`cell-${index}`} fill={entry.color} />
                   ))}
                 </Pie>
                 <Tooltip
-                  contentStyle={{
-                    backgroundColor: "#1f2937",
-                    border: "1px solid #374151",
-                    borderRadius: "8px",
-                    color: "#fff",
-                  }}
+                  contentStyle={
+                    theme === 'dark'
+                      ? {
+                          backgroundColor: "#1f2937",
+                          border: "1px solid #374151",
+                          borderRadius: "8px",
+                          color: "#fff",
+                        }
+                      : {
+                          backgroundColor: "#ffffff",
+                          border: "1px solid #e5e7eb",
+                          borderRadius: "8px",
+                          color: "#000",
+                        }
+                  }
                 />
               </PieChart>
             </ResponsiveContainer>
@@ -1229,10 +1252,10 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
       {/* Tables Row */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Recent Users Table */}
-        <Card className="bg-gray-800 border-gray-700">
+        <Card>
           <CardHeader>
-            <CardTitle className="flex items-center space-x-2 text-white">
-              <Calendar className="h-5 w-5 text-purple-400" />
+            <CardTitle className="flex items-center space-x-2 text-gray-900 dark:text-white">
+              <Calendar className="h-5 w-5 text-purple-600 dark:text-purple-400" />
               <span>Recent Users</span>
             </CardTitle>
           </CardHeader>
@@ -1240,17 +1263,17 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
             <div className="overflow-x-auto">
               <table className="w-full">
                 <thead>
-                  <tr className="border-b border-gray-600">
-                    <th className="text-left py-3 px-4 font-medium text-gray-300">
+                  <tr className="border-b border-gray-200 dark:border-gray-600">
+                    <th className="text-left py-3 px-4 font-medium text-gray-500 dark:text-gray-300">
                       User
                     </th>
-                    <th className="text-left py-3 px-4 font-medium text-gray-300">
+                    <th className="text-left py-3 px-4 font-medium text-gray-500 dark:text-gray-300">
                       Email
                     </th>
-                    <th className="text-left py-3 px-4 font-medium text-gray-300">
+                    <th className="text-left py-3 px-4 font-medium text-gray-500 dark:text-gray-300">
                       Role
                     </th>
-                    <th className="text-left py-3 px-4 font-medium text-gray-300">
+                    <th className="text-left py-3 px-4 font-medium text-gray-500 dark:text-gray-300">
                       Joined
                     </th>
                   </tr>
@@ -1259,7 +1282,7 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                   {recentUsers.slice(0, 5).map((user) => (
                     <tr
                       key={user.id}
-                      className="border-b border-gray-700 hover:bg-gray-700/50 transition-colors"
+                      className="border-b border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
                     >
                       <td className="py-3 px-4">
                         <div className="flex items-center space-x-3">
@@ -1271,30 +1294,30 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                               className="h-8 w-8 rounded-full object-cover"
                             />
                           ) : (
-                            <div className="h-8 w-8 rounded-full bg-gray-600 flex items-center justify-center">
-                              <Users className="h-4 w-4 text-gray-300" />
+                            <div className="h-8 w-8 rounded-full bg-gray-300 dark:bg-gray-600 flex items-center justify-center">
+                              <Users className="h-4 w-4 text-gray-500 dark:text-gray-300" />
                             </div>
                           )}
-                          <span className="font-medium text-white">
+                          <span className="font-medium text-gray-900 dark:text-white">
                             {user.name || "No name"}
                           </span>
                         </div>
                       </td>
-                      <td className="py-3 px-4 text-gray-300">{user.email}</td>
+                      <td className="py-3 px-4 text-gray-700 dark:text-gray-300">{user.email}</td>
                       <td className="py-3 px-4">
                         <Badge
                           variant="secondary"
                           className={`
-                            ${user.role === "ADMIN" ? "bg-red-900/50 text-red-200 border-red-700" : ""}
-                            ${user.role === "MODERATOR" ? "bg-yellow-900/50 text-yellow-200 border-yellow-700" : ""}
-                            ${user.role === "USER" ? "bg-green-900/50 text-green-200 border-green-700" : ""}
-                            ${user.role === "GUEST" ? "bg-gray-700 text-gray-200 border-gray-600" : ""}
+                            ${user.role === "ADMIN" ? "bg-red-100 text-red-700 border-red-200 dark:bg-red-900/50 dark:text-red-200 dark:border-red-700" : ""}
+                            ${user.role === "MODERATOR" ? "bg-yellow-100 text-yellow-700 border-yellow-200 dark:bg-yellow-900/50 dark:text-yellow-200 dark:border-yellow-700" : ""}
+                            ${user.role === "USER" ? "bg-green-100 text-green-700 border-green-200 dark:bg-green-900/50 dark:text-green-200 dark:border-green-700" : ""}
+                            ${user.role === "GUEST" ? "bg-gray-100 text-gray-700 border-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:border-gray-600" : ""}
                           `}
                         >
                           {user.role}
                         </Badge>
                       </td>
-                      <td className="py-3 px-4 text-gray-400">
+                      <td className="py-3 px-4 text-gray-500 dark:text-gray-400">
                         {new Date(user.createdAt).toLocaleDateString()}
                       </td>
                     </tr>
@@ -1306,17 +1329,17 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
         </Card>
 
         {/* Recent Activity Table */}
-        <Card className="bg-gray-800 border-gray-700">
+        <Card>
           <CardHeader>
-            <CardTitle className="flex items-center space-x-2 text-white">
-              <Activity className="h-5 w-5 text-green-400" />
+            <CardTitle className="flex items-center space-x-2 text-gray-900 dark:text-white">
+              <Activity className="h-5 w-5 text-green-600 dark:text-green-400" />
               <span>Recent Content Generation</span>
             </CardTitle>
           </CardHeader>
           <CardContent>
             {isLoadingContentStats ? (
               <div className="flex justify-center py-8">
-                <div className="flex items-center text-gray-400">
+                <div className="flex items-center text-gray-600 dark:text-gray-400">
                   <Loader2 className="h-6 w-6 animate-spin mr-2" />
                   <span>Loading recent activity...</span>
                 </div>
@@ -1325,17 +1348,17 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
               <div className="overflow-x-auto">
                 <table className="w-full">
                   <thead>
-                    <tr className="border-b border-gray-600">
-                      <th className="text-left py-3 px-4 font-medium text-gray-300">
+                    <tr className="border-b border-gray-200 dark:border-gray-600">
+                      <th className="text-left py-3 px-4 font-medium text-gray-500 dark:text-gray-300">
                         User
                       </th>
-                      <th className="text-left py-3 px-4 font-medium text-gray-300">
+                      <th className="text-left py-3 px-4 font-medium text-gray-500 dark:text-gray-300">
                         Model
                       </th>
-                      <th className="text-left py-3 px-4 font-medium text-gray-300">
+                      <th className="text-left py-3 px-4 font-medium text-gray-500 dark:text-gray-300">
                         Activity
                       </th>
-                      <th className="text-left py-3 px-4 font-medium text-gray-300">
+                      <th className="text-left py-3 px-4 font-medium text-gray-500 dark:text-gray-300">
                         Tracker
                       </th>
                     </tr>
@@ -1345,7 +1368,7 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                       return (
                         <tr
                           key={index}
-                          className="border-b border-gray-700 hover:bg-gray-700/50 transition-colors"
+                          className="border-b border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
                         >
                           <td className="py-2 px-4">
                             <div className="flex items-center space-x-3">
@@ -1367,7 +1390,7 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                                   />
                                 ) : null}
                                 <div
-                                  className="w-full h-full bg-purple-500 rounded-full flex items-center justify-center"
+                                  className="w-full h-full bg-purple-500 rounded-full flex items-center justify-center" // Fallback color can remain specific if desired
                                   style={{
                                     display: activity.image ? "none" : "flex",
                                   }}
@@ -1378,10 +1401,10 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                                 </div>
                               </div>
                               <div className="flex-1 min-w-0">
-                                <p className="text-sm font-medium text-white truncate">
+                                <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
                                   {activity.name}
                                 </p>
-                                <p className="text-sm text-gray-400 truncate">
+                                <p className="text-sm text-gray-500 dark:text-gray-400 truncate">
                                   {(() => {
                                     if (!activity.createdAt) return "Recently";
                                     const now = new Date();
@@ -1411,27 +1434,27 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                                   })()}
                                 </p>
                               </div>
-                              <div className="text-xs text-gray-400">
+                              <div className="text-xs text-gray-500 dark:text-gray-400">
                                 {activity.tracker}
                               </div>
                             </div>
                           </td>
-                          <td className="py-3 px-4 text-gray-300 text-sm">
+                          <td className="py-3 px-4 text-gray-700 dark:text-gray-300 text-sm">
                             <div className="max-w-[120px] truncate">
                               {activity.model || "N/A"}
                             </div>
                           </td>
-                          <td className="py-3 px-4 text-gray-300 text-sm">
+                          <td className="py-3 px-4 text-gray-700 dark:text-gray-300 text-sm">
                             Generated content
                           </td>
                           <td className="py-3 px-4">
                             <Badge
                               variant="secondary"
                               className={`text-xs
-                                ${activity.tracker === "VIP Gen Tracker" ? "bg-purple-900/50 text-purple-200 border-purple-700" : ""}
-                                ${activity.tracker === "Live Gen Tracker" ? "bg-red-900/50 text-red-200 border-red-700" : ""}
-                                ${activity.tracker === "FTT Gen Tracker" ? "bg-blue-900/50 text-blue-200 border-blue-700" : ""}
-                                ${activity.tracker === "AI Gen Tracker" ? "bg-green-900/50 text-green-200 border-green-700" : ""}
+                                ${activity.tracker === "VIP Gen Tracker" ? "bg-purple-100 text-purple-700 border-purple-200 dark:bg-purple-900/50 dark:text-purple-200 dark:border-purple-700" : ""}
+                                ${activity.tracker === "Live Gen Tracker" ? "bg-red-100 text-red-700 border-red-200 dark:bg-red-900/50 dark:text-red-200 dark:border-red-700" : ""}
+                                ${activity.tracker === "FTT Gen Tracker" ? "bg-blue-100 text-blue-700 border-blue-200 dark:bg-blue-900/50 dark:text-blue-200 dark:border-blue-700" : ""}
+                                ${activity.tracker === "AI Gen Tracker" ? "bg-green-100 text-green-700 border-green-200 dark:bg-green-900/50 dark:text-green-200 dark:border-green-700" : ""}
                               `}
                             >
                               {activity.tracker.replace(" Gen Tracker", "")}
@@ -1444,7 +1467,7 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                 </table>
               </div>
             ) : (
-              <div className="text-center text-gray-400 py-8">
+              <div className="text-center text-gray-600 dark:text-gray-400 py-8">
                 <FileText className="h-12 w-12 mx-auto mb-4 opacity-50" />
                 <p className="text-sm">
                   No recent content generation activity found
@@ -1458,10 +1481,10 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
       {/* Charts Row */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* VN Sales by Model */}
-        <Card className="bg-gray-800 border-gray-700">
+        <Card>
           <CardHeader>
-            <CardTitle className="flex items-center space-x-2 text-white">
-              <DollarSign className="h-5 w-5 text-orange-400" />
+            <CardTitle className="flex items-center space-x-2 text-gray-900 dark:text-white">
+              <DollarSign className="h-5 w-5 text-orange-600 dark:text-orange-400" />
               <span>VN Sales by Model</span>
             </CardTitle>
           </CardHeader>
@@ -1469,7 +1492,7 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
             <div className="space-y-4">
               {isLoadingVnStats ? (
                 <div className="flex justify-center py-8">
-                  <div className="flex items-center text-gray-400">
+                  <div className="flex items-center text-gray-600 dark:text-gray-400">
                     <Loader2 className="h-6 w-6 animate-spin mr-2" />
                     <span>Fetching sales data from Google Sheets...</span>
                   </div>
@@ -1479,28 +1502,28 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                   {vnSales.salesByModel.map((model, index) => (
                     <div
                       key={index}
-                      className="flex items-center justify-between p-4 bg-gray-700/50 rounded-lg"
+                      className="flex items-center justify-between p-4 bg-gray-100 dark:bg-gray-700/50 rounded-lg"
                     >
                       <div>
-                        <h3 className="font-medium text-white">{model.name}</h3>
-                        <p className="text-sm text-gray-400">
+                        <h3 className="font-medium text-gray-900 dark:text-white">{model.name}</h3>
+                        <p className="text-sm text-gray-500 dark:text-gray-400">
                           {model.sales} VN sales
                         </p>
                       </div>
                       <div className="text-right">
-                        <p className="font-semibold text-green-400">
+                        <p className="font-semibold text-green-600 dark:text-green-400">
                           ${model.revenue.toFixed(2)}
                         </p>
-                        <p className="text-sm text-gray-400">
+                        <p className="text-sm text-gray-500 dark:text-gray-400">
                           {model.loyaltyPoints} loyalty pts
                         </p>
                       </div>
                     </div>
                   ))}
-                  <div className="text-center text-gray-400 py-4">
+                  <div className="text-center text-gray-600 dark:text-gray-400 py-4">
                     <p className="text-sm">
                       Average VN Price:{" "}
-                      <span className="text-orange-400 font-semibold">
+                      <span className="text-orange-600 dark:text-orange-400 font-semibold">
                         ${vnSales.averageVnPrice.toFixed(2)}
                       </span>{" "}
                       (+${vnSales.priceIncrease} from last week)
@@ -1508,7 +1531,7 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                   </div>
                 </>
               ) : (
-                <div className="text-center text-gray-400 py-4">
+                <div className="text-center text-gray-600 dark:text-gray-400 py-4">
                   <p className="text-sm">
                     No sales data found. Submit some sales to see analytics!
                   </p>
@@ -1519,10 +1542,10 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
         </Card>
 
         {/* Content Generation by Tracker */}
-        <Card className="bg-gray-800 border-gray-700">
+        <Card>
           <CardHeader>
-            <CardTitle className="flex items-center space-x-2 text-white">
-              <BarChart3 className="h-5 w-5 text-purple-400" />
+            <CardTitle className="flex items-center space-x-2 text-gray-900 dark:text-white">
+              <BarChart3 className="h-5 w-5 text-purple-600 dark:text-purple-400" />
               <span>Content Generation by Tracker</span>
             </CardTitle>
           </CardHeader>
@@ -1530,7 +1553,7 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
             <div className="space-y-4">
               {isLoadingContentStats ? (
                 <div className="flex justify-center py-8">
-                  <div className="flex items-center text-gray-400">
+                  <div className="flex items-center text-gray-600 dark:text-gray-400">
                     <Loader2 className="h-6 w-6 animate-spin mr-2" />
                     <span>Fetching content data from Google Sheets...</span>
                   </div>
@@ -1541,31 +1564,31 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                     (tracker, index) => (
                       <div
                         key={index}
-                        className="flex items-center justify-between p-4 bg-gray-700/50 rounded-lg"
+                        className="flex items-center justify-between p-4 bg-gray-100 dark:bg-gray-700/50 rounded-lg"
                       >
                         <div>
-                          <h3 className="font-medium text-white">
+                          <h3 className="font-medium text-gray-900 dark:text-white">
                             {tracker.tracker}
                           </h3>
-                          <p className="text-sm text-gray-400">
+                          <p className="text-sm text-gray-500 dark:text-gray-400">
                             Content generation tracker
                           </p>
                         </div>
                         <div className="text-right">
-                          <p className="font-semibold text-purple-400">
+                          <p className="font-semibold text-purple-600 dark:text-purple-400">
                             {tracker.count.toLocaleString()}
                           </p>
-                          <p className="text-sm text-gray-400">
+                          <p className="text-sm text-gray-500 dark:text-gray-400">
                             items generated
                           </p>
                         </div>
                       </div>
                     )
                   )}
-                  <div className="text-center text-gray-400 py-4">
+                  <div className="text-center text-gray-600 dark:text-gray-400 py-4">
                     <p className="text-sm">
                       Total Content Generated:{" "}
-                      <span className="text-purple-400 font-semibold">
+                      <span className="text-purple-600 dark:text-purple-400 font-semibold">
                         {contentGenerationData.totalContentGenerated.toLocaleString()}{" "}
                       </span>{" "}
                       (+{contentGenerationData.contentGrowth}% growth)
@@ -1573,7 +1596,7 @@ export function AdminDashboardClient({ data }: { data: DashboardData }) {
                   </div>
                 </>
               ) : (
-                <div className="text-center text-gray-400 py-4">
+                <div className="text-center text-gray-600 dark:text-gray-400 py-4">
                   <p className="text-sm">
                     No content generation data found. Generate some content to
                     see analytics!

--- a/components/admin/ThemeProvider.tsx
+++ b/components/admin/ThemeProvider.tsx
@@ -68,9 +68,9 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
   return (
     <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
-      <div className={theme} data-theme={theme}>
+      <>
         {children}
-      </div>
+      </>
     </ThemeContext.Provider>
   );
 }


### PR DESCRIPTION
This commit addresses issues with the dark mode toggle in the admin section and ensures components correctly adapt to light and dark themes.

Key changes:

1.  **Theme Toggle and Provider:**
    - Removed a conflicting inline script from `app/(admin)/layout.tsx` that handled initial theme setting. `ThemeProvider` is now the sole authority.
    - Ensured `ThemeProvider` correctly updates `<html>` and `<body>` tags.
    - Removed the OS-level `@media (prefers-color-scheme: dark)` CSS override in `app/globals.css` that interfered with the JavaScript theme toggle, giving the application full control over the active theme.

2.  **Component Styling (`app/(admin)/admin/users/page.tsx`, `components/admin/AdminDashboardClient.tsx`):**
    - Updated numerous components to use theme-aware styling.
    - Removed hardcoded dark theme styles (e.g., `bg-gray-800`) from `Card` component usage, allowing them to utilize their default CSS variable-based theming.
    - Applied appropriate light and `dark:` variant classes for text, backgrounds, borders, and icons.
    - Corrected `Badge` component usage to leverage its built-in themeable variants or apply fully theme-aware custom classes.
    - Implemented dynamic styling for `recharts` elements in `AdminDashboardClient.tsx` using the `useTheme` hook to ensure charts are legible in both light and dark modes.

These changes should result in a consistent and functional light/dark mode experience across the admin pages, with the sidebar toggle now working as expected.