### PR TITLE
Fix: Resolve system theme interference with in-app admin theme toggle

### DIFF
--- a/app/(admin)/layout.tsx
+++ b/app/(admin)/layout.tsx
@@ -9,7 +9,12 @@ export default function AdminLayout({
 }) {
   return (
     <>
-      <NextThemesProvider attribute="class" defaultTheme="dark" storageKey="admin-theme">
+      <NextThemesProvider
+        attribute="class"
+        defaultTheme="dark"
+        storageKey="admin-theme"
+        enableSystem={false}
+      >
         <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
           <AdminSidebar />
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,18 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: 'class', // Crucial for next-themes to control dark mode
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./pages/**/*.{js,ts,jsx,tsx,mdx}", // Added pages just in case
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  theme: {
+    extend: {
+      // If there were previous theme extensions, they would be re-added here.
+      // For now, assuming default extensions are sufficient.
+    },
+  },
+  plugins: [
+    // If there were previous plugins, they would be re-added here.
+  ],
+};


### PR DESCRIPTION
This commit addresses the issue where OS/browser theme preferences interfered with the application's manual theme toggle in the admin section.

The root causes were identified as:
1. Tailwind CSS not being explicitly configured for class-based dark mode, potentially defaulting to or prioritizing media query-based theming.
2. `next-themes` `ThemeProvider` defaulting to `enableSystem=true`, which allowed system preferences to affect theme application even when an in-app selection was made.

Changes implemented:
1.  **Created `tailwind.config.js`:**
    - Added a `tailwind.config.js` file to the project root.
    - Explicitly set `darkMode: 'class'` to ensure Tailwind's `dark:` variants are triggered by the `.dark` class on the `<html>` element, as managed by `next-themes`.
    - Included standard content paths for `app`, `pages`, and `components`.

2.  **Updated `NextThemesProvider` in `app/(admin)/layout.tsx`:**
    - Set the `enableSystem={false}` prop on the `NextThemesProvider`. This makes the in-app theme selection (stored in the `admin-theme` cookie or falling back to `defaultTheme`) the sole source of truth, ignoring OS/browser theme settings after initial load.

These changes ensure that the theme selected via the admin sidebar toggle is consistently applied across all components, providing a predictable and user-controlled theming experience.