### PR TITLE
Fix: Enforce app-selected theme over system/browser preferences

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -116,6 +116,34 @@
   --sidebar-ring: oklch(0.551 0.027 264.364);
 }
 
+/* --- START: High-specificity theme overrides --- */
+
+html.light {
+  color-scheme: light !important;
+}
+
+html.dark {
+  color-scheme: dark !important;
+}
+
+/*
+  Ensure these use the CSS variables defined in :root and .dark respectively.
+  The ThemeProvider already adds 'light' or 'dark' to the html element.
+*/
+html.light body {
+  background-color: var(--background) !important;
+  color: var(--foreground) !important;
+}
+
+html.dark body {
+  /* The --background and --foreground variables are already redefined within the .dark scope */
+  /* So, this will pick up the dark theme variables correctly. */
+  background-color: var(--background) !important;
+  color: var(--foreground) !important;
+}
+
+/* --- END: High-specificity theme overrides --- */
+
 @layer base {
   * {
     @apply border-border outline-ring/50;


### PR DESCRIPTION
This commit introduces high-specificity CSS overrides in `app/globals.css` to ensure that the theme you selected via the in-app toggle (light or dark) is strictly applied to the admin section, regardless of your OS or browser theme settings.

Previously, even with `next-themes` configured with `enableSystem={false}` and Tailwind CSS set to `darkMode: 'class'`, some components reportedly retained styles influenced by the system theme. This was likely due to CSS specificity issues where browser default styles or Tailwind base/utility styles under certain conditions were not fully overridden by the application's theme classes.

Changes implemented in `app/globals.css`:
- Added `html.light { color-scheme: light !important; }` and `html.dark { color-scheme: dark !important; }` to force the browser's interpretation of UI elements (like scrollbars, default form controls) to match the selected theme.
- Added `html.light body { background-color: var(--background) !important; color: var(--foreground) !important; }` and `html.dark body { background-color: var(--background) !important; color: var(--foreground) !important; }` to ensure the fundamental page background and text colors strictly adhere to the application's theme variables.

These overrides should provide the necessary specificity to make the in-app theme selection consistently authoritative.